### PR TITLE
Bugfix for Radau-refactorization: do not skip LU factorization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
     * Refactored Radau5 C implementation; moved to thirdparts/radau5/.
     * Replaced event localization for explicit problems with an equivalent C implementation.
     * Added missing counts on event indicator evaluations when setting problem data in solvers.
+    * Radau5 bugfix in introduced in re-factorization, do not skip LU-factorizations if no new Jacobian is needed.
 
 --- Assimulo-3.3.1 ---
     * Minor refactoring of Radau5 C implementation:

--- a/thirdparty/radau5/radau5.c
+++ b/thirdparty/radau5/radau5.c
@@ -286,7 +286,7 @@ static int _radcor(radau_mem_t *rmem, int n, FP_CB_f fcn, void *fcn_EXT,
 	int reject; /* switch if step is to be rejected */
     double h_output; /* backup stepsize for output */
 	double xold; /* previous time-point */
-    double hold; /* previos stepsize */
+    double hold; /* previous stepsize */
 	double hnew; /* new stepsize */
 	double err; /* local error norm, return from estrad */
 	double fac; /* stepsize adjustment factor */
@@ -359,7 +359,7 @@ L10:
 /*  COMPUTATION OF THE JACOBIAN */
 /* *** *** *** *** *** *** *** */
 	if (!rmem->new_jac_req){
-		goto L30; /* no new jacobian required; reuse old one + LU factorization */
+		goto L20; /* no new jacobian required; reuse old one*/
 	}
     rmem->stats->njac++;
     if (ijac == 0) {
@@ -431,7 +431,7 @@ L20:
 		#endif /*__RADAU5_WITH_SUPERLU*/
 	}
     rmem->stats->ludecomps++; /* increment LU decompositions counter */
-/* --- NEXT STEP, NO NEW JAC/LU */
+/* --- NEXT STEP */
 L30:
     rmem->stats->nsteps++;
     if (rmem->stats->nsteps > rmem->input->nmax) {

--- a/thirdparty/radau5/radau5_io.c
+++ b/thirdparty/radau5/radau5_io.c
@@ -434,13 +434,13 @@ static int _radau_setup_linsol_mem(radau_mem_t *rmem, int n, int sparseLU, int n
 		#endif /*__RADAU5_WITH_SUPERLU*/
 
 	}else{ /* DENSE */
-		rmem->lin_sol->jac = (double*)malloc(n_sq*sizeof(double));
-		rmem->lin_sol->e1  = (double*)malloc(n_sq*sizeof(double));
-		rmem->lin_sol->e2r = (double*)malloc(n_sq*sizeof(double));
-		rmem->lin_sol->e2i = (double*)malloc(n_sq*sizeof(double));
+		rmem->lin_sol->jac = (double*)calloc(n_sq, sizeof(double));
+		rmem->lin_sol->e1  = (double*)calloc(n_sq, sizeof(double));
+		rmem->lin_sol->e2r = (double*)calloc(n_sq, sizeof(double));
+		rmem->lin_sol->e2i = (double*)calloc(n_sq, sizeof(double));
 
-		rmem->lin_sol->ip1 = (int*)malloc(n*sizeof(int));
-		rmem->lin_sol->ip2 = (int*)malloc(n*sizeof(int));
+		rmem->lin_sol->ip1 = (int*)calloc(n, sizeof(int));
+		rmem->lin_sol->ip2 = (int*)calloc(n, sizeof(int));
 
 		if(!rmem->lin_sol->jac || !rmem->lin_sol->e1 || !rmem->lin_sol->e2r || !rmem->lin_sol->e2i || !rmem->lin_sol->ip1 || !rmem->lin_sol->ip2){
 			sprintf(rmem->err_log, MSG_MALLOC_FAIL);


### PR DESCRIPTION
malloc -> calloc change is since valgrind may otherwise detect false positives on if-statements involving uninitialized values.

No changelog entry, since this only fixes an unreleased bug from [https://github.com/modelon-community/Assimulo/pull/47](https://github.com/modelon-community/Assimulo/pull/47)