### PR TITLE
Resolved issue in cvode_gyro.py with scipy 1.10.1

### DIFF
--- a/examples/cvode_gyro.py
+++ b/examples/cvode_gyro.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2010 Modelon AB
+# Copyright (C) 2010-2023 Modelon AB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from scipy import *
+from numpy import stack as numpy_hstack
 import nose
 from assimulo.problem import Explicit_Problem
 from assimulo.solvers import CVode
@@ -54,7 +55,7 @@ def run_example(with_plots=True):
         omega=array([pi[0]/I1,pi[1]/I2,pi[2]/I3])
         pid=dot(curl(omega),pi)+f
         Qd=dot(curl(omega),Q)
-        return hstack([pid,Qd.reshape((9,))])
+        return numpy_hstack([pid,Qd.reshape((9,))])
 
     def energi(state):
         energi=[]
@@ -69,7 +70,7 @@ def run_example(with_plots=True):
         return energi
 
     #Initial conditions
-    y0=hstack([[1000.*10,5000.*10,6000*10],eye(3).reshape((9,))])
+    y0=numpy_hstack([[1000.*10,5000.*10,6000*10],eye(3).reshape((9,))])
     
     #Create an Assimulo explicit problem
     exp_mod = Explicit_Problem(f,y0, name="Gyroscope Example")


### PR DESCRIPTION
With scipy 1.10.1 you encounter an error as below:
```
ERROR: assimulo.tests.test_examples.Test_Examples.test_cvode_gyro
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/foo/pyenv/lib/python3.9/site-packages/assimulo/tests/test_examples.py", line 62, in test_cvode_gyro
    cvode_gyro.run_example(with_plots=False)
  File "/home/foo/pyenv/lib/python3.9/site-packages/assimulo/examples/cvode_gyro.py", line 72, in run_example
    y0=hstack([[1000.*10,5000.*10,6000*10],eye(3).reshape((9,))])
NameError: name 'hstack' is not defined
```
It looks like `scipy.hstack` has been removed but unable to find anything about it in the release notes.
Note however that the docstring from `scipy.hstack` (using scipy `1.7.1`) and the numpy function seems identical, thus perhaps it is simply a wrapper:
```
In [6]: import numpy as np

In [7]: np.hstack
Out[7]: <function numpy.hstack(tup)>

In [8]: np.hstack?
Signature: np.hstack(tup)
Docstring:
Stack arrays in sequence horizontally (column wise).

This is equivalent to concatenation along the second axis, except for 1-D
arrays where it concatenates along the first axis. Rebuilds arrays divided
by `hsplit`.

This function makes most sense for arrays with up to 3 dimensions. For
instance, for pixel-data with a height (first axis), width (second axis),
and r/g/b channels (third axis). The functions `concatenate`, `stack` and
`block` provide more general stacking and concatenation operations.

Parameters
----------
tup : sequence of ndarrays
    The arrays must have the same shape along all but the second axis,
    except 1-D arrays which can be any length.

Returns
-------
stacked : ndarray
    The array formed by stacking the given arrays.

See Also
--------
stack : Join a sequence of arrays along a new axis.
vstack : Stack arrays in sequence vertically (row wise).
dstack : Stack arrays in sequence depth wise (along third axis).
```

From scipy:
```
In [9]: import scipy

In [10]: scipy.hstack?
Signature: scipy.hstack(tup)
Docstring:
Stack arrays in sequence horizontally (column wise).

This is equivalent to concatenation along the second axis, except for 1-D
arrays where it concatenates along the first axis. Rebuilds arrays divided
by `hsplit`.

This function makes most sense for arrays with up to 3 dimensions. For
instance, for pixel-data with a height (first axis), width (second axis),
and r/g/b channels (third axis). The functions `concatenate`, `stack` and
`block` provide more general stacking and concatenation operations.

Parameters
----------
tup : sequence of ndarrays
    The arrays must have the same shape along all but the second axis,
    except 1-D arrays which can be any length.

Returns
-------
stacked : ndarray
    The array formed by stacking the given arrays.

See Also
--------
stack : Join a sequence of arrays along a new axis.
vstack : Stack arrays in sequence vertically (row wise).
dstack : Stack arrays in sequence depth wise (along third axis).
concatenate : Join a sequence of arrays along an existing axis.
hsplit : Split array along second axis.
block : Assemble arrays from blocks.

Examples
--------
>>> a = np.array((1,2,3))
>>> b = np.array((2,3,4))
>>> np.hstack((a,b))
array([1, 2, 3, 2, 3, 4])
>>> a = np.array([[1],[2],[3]])
>>> b = np.array([[2],[3],[4]])
>>> np.hstack((a,b))
array([[1, 2],
       [2, 3],
       [3, 4]])
File:      c:\foo\python37\lib\site-packages\numpy\core\shape_base.py
Type:      function
```