### PR TITLE
Removed all scipy references in cvode_gyro.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 --- CHANGELOG ---
+--- Assimulo-3.4.3 ---
+    * This version has replaced all redundant scipy references in one of the examples with numpy function calls. In order to improve compliance with newer versions of scipy.
+
 --- Assimulo-3.4.2 ---
     * Updated an import statement in one of the examples to resolve compliance issues with scipy 1.10.1.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 --- CHANGELOG ---
 --- Assimulo-3.4.3 ---
-    * This version has replaced all redundant scipy references in one of the examples with numpy function calls. In order to improve compliance with newer versions of scipy.
+    * Improved compliance with newer scipy version by instead using corresponding numpy calls when more suitable.
 
 --- Assimulo-3.4.2 ---
     * Updated an import statement in one of the examples to resolve compliance issues with scipy 1.10.1.

--- a/examples/cvode_gyro.py
+++ b/examples/cvode_gyro.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from scipy import *
-from numpy import hstack as numpy_hstack
+import numpy as np
 import nose
 from assimulo.problem import Explicit_Problem
 from assimulo.solvers import CVode
@@ -35,74 +34,60 @@ def run_example(with_plots=True):
     """
 
     def curl(v):
-        return array([[0,v[2],-v[1]],[-v[2],0,v[0]],[v[1],-v[0],0]])
+        return np.array([[0, v[2], -v[1]], [-v[2], 0, v[0]], [v[1], -v[0], 0]])
 
-    #Defines the rhs
-    def f(t,u):
+    # Defines the rhs
+    def f(t, u):
         """
         Simulations for the Gyro (Heavy Top) example in Celledoni/Safstrom: 
         Journal of Physics A, Vol 39, 5463-5478, 2006
         """
-        I1=1000.
-        I2=5000.
-        I3=6000.
-        u0=[0,0,1.]
-        pi=u[0:3]
-        Q=(u[3:12]).reshape((3,3))
-        Qu0=dot(Q,u0)
-        f=array([Qu0[1],-Qu0[0],0.])
-        f=0
-        omega=array([pi[0]/I1,pi[1]/I2,pi[2]/I3])
-        pid=dot(curl(omega),pi)+f
-        Qd=dot(curl(omega),Q)
-        return numpy_hstack([pid,Qd.reshape((9,))])
+        I1 = 1000.
+        I2 = 5000.
+        I3 = 6000.
+        u0 = [0, 0, 1.]
+        pi = u[0:3]
+        Q = (u[3:12]).reshape((3, 3))
+        Qu0 = np.dot(Q, u0)
+        omega = np.array([pi[0]/I1, pi[1]/I2, pi[2]/I3])
+        pid = np.dot(curl(omega), pi)
+        Qd = np.dot(curl(omega),Q)
+        return np.hstack([pid, Qd.reshape((9,))])
 
-    def energi(state):
-        energi=[]
-        for st in state:
-            Q=(st[3:12]).reshape((3,3))
-            pi=st[0:3]
-            u0=[0,0,1.]
-            Qu0=dot(Q,u0)
-            V=Qu0[2]  # potential energy
-            T=0.5*(pi[0]**2/1000.+pi[1]**2/5000.+pi[2]**2/6000.)
-            energi.append([T])
-        return energi
-
-    #Initial conditions
-    y0=numpy_hstack([[1000.*10,5000.*10,6000*10],eye(3).reshape((9,))])
+    # Initial conditions
+    y0 = np.hstack([[1000.*10, 5000.*10, 6000*10], np.eye(3).reshape((9,))])
     
-    #Create an Assimulo explicit problem
-    exp_mod = Explicit_Problem(f,y0, name="Gyroscope Example")
+    # Create an Assimulo explicit problem
+    exp_mod = Explicit_Problem(f, y0, name="Gyroscope Example")
     
-    #Create an Assimulo explicit solver (CVode)
-    exp_sim=CVode(exp_mod)
+    # Create an Assimulo explicit solver (CVode)
+    exp_sim = CVode(exp_mod)
     
-    #Sets the parameters
-    exp_sim.discr='BDF'
-    exp_sim.iter='Newton'
-    exp_sim.maxord=2 #Sets the maxorder
-    exp_sim.atol=1.e-10
-    exp_sim.rtol=1.e-10
+    # Sets the parameters
+    exp_sim.discr = 'BDF'
+    exp_sim.iter = 'Newton'
+    exp_sim.maxord = 2 # Sets the maxorder
+    exp_sim.atol = 1.e-10
+    exp_sim.rtol = 1.e-10
     
-    #Simulate
+    # Simulate
     t, y = exp_sim.simulate(0.1)
     
-    #Plot
+    # Plot
     if with_plots:
         import pylab as P
-        P.plot(t,y/10000.)
+        P.plot(t, y/10000.)
         P.xlabel('Time')
         P.ylabel('States, scaled by $10^4$')
         P.title(exp_mod.name)
         P.show()
     
     #Basic tests
-    nose.tools.assert_almost_equal(y[-1][0],692.800241862)
-    nose.tools.assert_almost_equal(y[-1][8],7.08468221e-1)
+    nose.tools.assert_almost_equal(y[-1][0], 692.800241862)
+    nose.tools.assert_almost_equal(y[-1][8], 7.08468221e-1)
     
     return exp_mod, exp_sim    
 
 
 if __name__=='__main__':
-    mod,sim = run_example()
+    mod, sim = run_example()


### PR DESCRIPTION
After I created the tag 3.4.2 I discovered further references to scipy functions that did not work with 1.10.1. This should be the last set of changes as the example works for me locally.

I also fixed some formatting issues and removed the function `energi` as it was not even used in the example. I will have to release Assimulo 3.4.3 after this.

```
In [1]: import scipy

In [2]: scipy.__version__
Out[2]: '1.10.1'

In [3]: from assimulo.examples import cvode_gyro

In [4]: cvode_gyro.run_example()
Final Run Statistics: Gyroscope Example

 Number of steps                                 : 3296
 Number of function evaluations                  : 3408
 Number of Jacobian evaluations                  : 55
 Number of function eval. due to Jacobian eval.  : 660
 Number of error test failures                   : 0
 Number of nonlinear iterations                  : 3404
 Number of nonlinear convergence failures        : 0

Solver options:

 Solver                   : CVode
 Linear multistep method  : BDF
 Nonlinear solver         : Newton
 Linear solver type       : DENSE
 Maximal order            : 2
 Tolerances (absolute)    : 1e-10
 Tolerances (relative)    : 1e-10

Simulation interval    : 0.0 - 0.1 seconds.
Elapsed simulation time: 0.25140339999779826 seconds.
```