### PR TITLE
Fixing setup.py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -665,7 +665,7 @@ ext_list += prepare.fortran_extensionlists()
 NAME = "Assimulo"
 AUTHOR = u"C. Winther (Andersson), C. Führer, J. Åkesson, M. Gäfvert"
 AUTHOR_EMAIL = "christian.winther@modelon.com"
-VERSION = "trunk" if version_number_arg == "Default" else version_number_arg
+VERSION = "3.5.0-dev" if version_number_arg == "Default" else version_number_arg
 LICENSE = "LGPL"
 URL = "http://www.jmodelica.org/assimulo"
 DOWNLOAD_URL = "http://www.jmodelica.org/assimulo"


### PR DESCRIPTION
Setuptools doesn't seem to like VERSION="trunk" anymore, I think using the same format as PyFMI seems better, we still want to have some distinction to the actual releases.