### PR TITLE
Unpin scipy upper version limit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: '3.9.x'
     - name: Setup Python
       run: |
-        python3 -m pip install Cython numpy scipy==1.12.0 matplotlib nose-py3 setuptools==69.1.0
+        python3 -m pip install Cython "numpy<2" scipy matplotlib nose-py3 setuptools==69.1.0
     - name: Install system
       run: |
         sudo apt-get -y install cmake liblapack-dev libsuitesparse-dev libhypre-dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ python_requires = >=3.9
 
 install_requires =
     numpy >= 1.19.5
-    scipy >= 1.10.1, < 1.13.0
+    scipy >= 1.10.1
     cython >= 3.0.7
     nose-py3 >= 1.6.3
     matplotlib > 3


### PR DESCRIPTION
Rationale:  It works fine with 1.13 and with have no indication that something will break with the next minor versions (and no major version bump in sight)