### PR TITLE
Fixing error messages from uninitialized CVode linear solver memory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 --- CHANGELOG ---
 
 --- Assimulo-FUTURE---
+    * Fixed error messages from uninitialized internal memory for CVode when using `iter = 'FixedPoint'`.
 
 --- Assimulo-3.7.0---
     * New CVode option: `maxstepshnil` (default = 10). Enforces a minimal stepsize 

--- a/src/solvers/sundials.pyx
+++ b/src/solvers/sundials.pyx
@@ -3327,31 +3327,32 @@ cdef class CVode(Explicit_ODE):
         if self.cvode_mem == NULL:
             raise CVodeError(CV_MEM_FAIL)
 
-        if self.options["linear_solver"] == "SPGMR":
-            IF SUNDIALS_VERSION >= (4,0,0):
-                flag = SUNDIALS.CVodeGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
-                flag = SUNDIALS.CVodeGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
-            ELSE:
-                flag = SUNDIALS.CVSpilsGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
-                flag = SUNDIALS.CVSpilsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
-            self.statistics["njacvecs"]  += njvevals
-        elif self.options["linear_solver"] == "SPARSE":
-            IF SUNDIALS_VERSION >= (3,0,0):
+        if self.options["iter"] == "Newton": # Requires structure otherwise not initialized, see initialize_options
+            if self.options["linear_solver"] == "SPGMR":
                 IF SUNDIALS_VERSION >= (4,0,0):
-                    flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals)
+                    flag = SUNDIALS.CVodeGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
+                    flag = SUNDIALS.CVodeGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
                 ELSE:
-                    flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals)
-            ELSE:
-                flag = SUNDIALS.CVSlsGetNumJacEvals(self.cvode_mem, &njevals)
-            self.statistics["njacs"]   += njevals
-        else:
-            IF SUNDIALS_VERSION >= (4,0,0):
-                flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
-                flag = SUNDIALS.CVodeGetNumLinRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
-            ELSE:
-                flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
-                flag = SUNDIALS.CVDlsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
-            self.statistics["njacs"]   += njevals
+                    flag = SUNDIALS.CVSpilsGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
+                    flag = SUNDIALS.CVSpilsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
+                self.statistics["njacvecs"]  += njvevals
+            elif self.options["linear_solver"] == "SPARSE":
+                IF SUNDIALS_VERSION >= (3,0,0):
+                    IF SUNDIALS_VERSION >= (4,0,0):
+                        flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals)
+                    ELSE:
+                        flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals)
+                ELSE:
+                    flag = SUNDIALS.CVSlsGetNumJacEvals(self.cvode_mem, &njevals)
+                self.statistics["njacs"]   += njevals
+            else:
+                IF SUNDIALS_VERSION >= (4,0,0):
+                    flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
+                    flag = SUNDIALS.CVodeGetNumLinRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
+                ELSE:
+                    flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
+                    flag = SUNDIALS.CVDlsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
+                self.statistics["njacs"]   += njevals
         if self.pData.PREC_SOLVE != NULL:
             IF SUNDIALS_VERSION >= (4,0,0):
                 flag = SUNDIALS.CVodeGetNumPrecSolves(self.cvode_mem, &npsolves)

--- a/src/solvers/sundials.pyx
+++ b/src/solvers/sundials.pyx
@@ -3330,11 +3330,11 @@ cdef class CVode(Explicit_ODE):
         if self.options["iter"] == "Newton": # Requires structure otherwise not initialized, see initialize_options
             if self.options["linear_solver"] == "SPGMR":
                 IF SUNDIALS_VERSION >= (4,0,0):
-                    flag = SUNDIALS.CVodeGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
-                    flag = SUNDIALS.CVodeGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
+                    flag = SUNDIALS.CVodeGetNumJtimesEvals(self.cvode_mem, &njvevals) # Number of jac*vector
+                    flag = SUNDIALS.CVodeGetNumRhsEvals(self.cvode_mem, &nfevalsLS) # Number of rhs due to jac*vector
                 ELSE:
-                    flag = SUNDIALS.CVSpilsGetNumJtimesEvals(self.cvode_mem, &njvevals) #Number of jac*vector
-                    flag = SUNDIALS.CVSpilsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of rhs due to jac*vector
+                    flag = SUNDIALS.CVSpilsGetNumJtimesEvals(self.cvode_mem, &njvevals) # Number of jac*vector
+                    flag = SUNDIALS.CVSpilsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) # Number of rhs due to jac*vector
                 self.statistics["njacvecs"]  += njvevals
             elif self.options["linear_solver"] == "SPARSE":
                 IF SUNDIALS_VERSION >= (3,0,0):
@@ -3347,11 +3347,11 @@ cdef class CVode(Explicit_ODE):
                 self.statistics["njacs"]   += njevals
             else:
                 IF SUNDIALS_VERSION >= (4,0,0):
-                    flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
-                    flag = SUNDIALS.CVodeGetNumLinRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
+                    flag = SUNDIALS.CVodeGetNumJacEvals(self.cvode_mem, &njevals) # Number of jac evals
+                    flag = SUNDIALS.CVodeGetNumLinRhsEvals(self.cvode_mem, &nfevalsLS) # Number of res evals due to jac evals
                 ELSE:
-                    flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals) #Number of jac evals
-                    flag = SUNDIALS.CVDlsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) #Number of res evals due to jac evals
+                    flag = SUNDIALS.CVDlsGetNumJacEvals(self.cvode_mem, &njevals) # Number of jac evals
+                    flag = SUNDIALS.CVDlsGetNumRhsEvals(self.cvode_mem, &nfevalsLS) # Number of res evals due to jac evals
                 self.statistics["njacs"]   += njevals
         if self.pData.PREC_SOLVE != NULL:
             IF SUNDIALS_VERSION >= (4,0,0):


### PR DESCRIPTION
Simply fix of hiding the messages; Only calling the relevant functions if we know the linear solver memory has been initialized.